### PR TITLE
Make sure `uniqueItems` also works with objects

### DIFF
--- a/src/__tests__/RAMLValidator-test.js
+++ b/src/__tests__/RAMLValidator-test.js
@@ -1024,6 +1024,42 @@ describe('RAMLValidator', function () {
         expect(errors.length).toEqual(1);
       });
 
+      it('should validate if all object items are unique', function () {
+        var errors = this.validator([
+          {
+            foo: 1,
+            bar: 2
+          },
+          {
+            foo: 2,
+            bar: 3
+          },
+          {
+            foo: 3,
+            bar: 4
+          }
+        ]);
+        expect(errors.length).toEqual(0);
+      });
+
+      it('should return error if there are duplicate objects', function () {
+        var errors = this.validator([
+          {
+            foo: 1,
+            bar: 2
+          },
+          {
+            foo: 2,
+            bar: 3
+          },
+          {
+            foo: 1,
+            bar: 2
+          }
+        ]);
+        expect(errors.length).toEqual(1);
+      });
+
     });
 
     describe('#items', function () {

--- a/src/generators/FacetValidators.js
+++ b/src/generators/FacetValidators.js
@@ -226,7 +226,7 @@ const FACET_FRAGMENT_GENERATORS = {
       'if ((function() {',
       '\tvar valuesSoFar = Object.create(null);',
       '\tfor (var i = 0; i < value.length; ++i) {',
-      '\t\tvar val = value[i];',
+      '\t\tvar val = JSON.stringify(value[i]);',
       '\t\tif (val in valuesSoFar) {',
       '\t\t\treturn true;',
       '\t\t}',


### PR DESCRIPTION
This PR ensures that the `uniqueItems` facet also works with object values.