### PR TITLE
DCOS-17611: replace const from RAMLErrorPayload for IE10 compatibility

### DIFF
--- a/lib/raml-validator-loader.js
+++ b/lib/raml-validator-loader.js
@@ -43,7 +43,7 @@ module.exports =
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -146,21 +146,21 @@ module.exports =
 	  return _Generator2.default.generate(ctx);
 	};
 
-/***/ },
+/***/ }),
 /* 1 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	module.exports = require("fs");
 
-/***/ },
+/***/ }),
 /* 2 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	module.exports = require("raml-1-parser");
 
-/***/ },
+/***/ }),
 /* 3 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -297,9 +297,9 @@ module.exports =
 
 	};
 
-/***/ },
+/***/ }),
 /* 4 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	'use strict';
 
@@ -344,9 +344,9 @@ module.exports =
 
 	exports.default = DefaultErrorMessages;
 
-/***/ },
+/***/ }),
 /* 5 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	'use strict';
 
@@ -368,9 +368,9 @@ module.exports =
 	  }
 	};
 
-/***/ },
+/***/ }),
 /* 6 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	"use strict";
 
@@ -378,11 +378,11 @@ module.exports =
 	 * The following string defines the RAMLError class, instantiated by the
 	 * validator when an error occurs.
 	 */
-	module.exports = "\nconst REPLACE_MESSAGE_TEMPLATE = /\\{\\{([^\\}]+)\\}\\}/g;\n\nfunction RAMLError(path, context, type, _messageVariables) {\n  var messageVariables = _messageVariables || {};\n  var message = context.ERROR_MESSAGES[type];\n  Object.defineProperties(this, {\n    message: {\n      enumerable: true,\n      get: function() {\n        if (typeof message === 'function') {\n          return message(messageVariables, path);\n        }\n\n        return message.replace(REPLACE_MESSAGE_TEMPLATE, function(match) {\n          return ''+messageVariables[match.slice(2,-2)] || '';\n        });\n      }\n    },\n    path: {\n      enumerable: true,\n      value: path\n    },\n    type: {\n      enumerable: true,\n      value: type\n    },\n    variables: {\n      enumerable: true,\n      value: messageVariables\n    }\n  });\n}\n";
+	module.exports = "\nvar REPLACE_MESSAGE_TEMPLATE = /\\{\\{([^\\}]+)\\}\\}/g;\n\nfunction RAMLError(path, context, type, _messageVariables) {\n  var messageVariables = _messageVariables || {};\n  var message = context.ERROR_MESSAGES[type];\n  Object.defineProperties(this, {\n    message: {\n      enumerable: true,\n      get: function() {\n        if (typeof message === 'function') {\n          return message(messageVariables, path);\n        }\n\n        return message.replace(REPLACE_MESSAGE_TEMPLATE, function(match) {\n          return ''+messageVariables[match.slice(2,-2)] || '';\n        });\n      }\n    },\n    path: {\n      enumerable: true,\n      value: path\n    },\n    type: {\n      enumerable: true,\n      value: type\n    },\n    variables: {\n      enumerable: true,\n      value: messageVariables\n    }\n  });\n}\n";
 
-/***/ },
+/***/ }),
 /* 7 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -633,15 +633,15 @@ module.exports =
 	  }
 	};
 
-/***/ },
+/***/ }),
 /* 8 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	module.exports = require("crypto");
 
-/***/ },
+/***/ }),
 /* 9 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -711,9 +711,9 @@ module.exports =
 	  }
 	};
 
-/***/ },
+/***/ }),
 /* 10 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -990,9 +990,9 @@ module.exports =
 
 	module.exports = HighOrderComposers;
 
-/***/ },
+/***/ }),
 /* 11 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -1319,9 +1319,9 @@ module.exports =
 	  }
 	};
 
-/***/ },
+/***/ }),
 /* 12 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	'use strict';
 
@@ -1348,9 +1348,9 @@ module.exports =
 	  }
 	};
 
-/***/ },
+/***/ }),
 /* 13 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -1526,9 +1526,9 @@ module.exports =
 	  }
 	};
 
-/***/ },
+/***/ }),
 /* 14 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
@@ -1705,5 +1705,5 @@ module.exports =
 
 	module.exports = GeneratorContext;
 
-/***/ }
+/***/ })
 /******/ ]);

--- a/src/constants/RAMLErrorPayload.js
+++ b/src/constants/RAMLErrorPayload.js
@@ -3,7 +3,7 @@
  * validator when an error occurs.
  */
 module.exports = `
-const REPLACE_MESSAGE_TEMPLATE = /\\{\\{([^\\}]+)\\}\\}/g;
+var REPLACE_MESSAGE_TEMPLATE = /\\{\\{([^\\}]+)\\}\\}/g;
 
 function RAMLError(path, context, type, _messageVariables) {
   var messageVariables = _messageVariables || {};


### PR DESCRIPTION
Replace the `const` from RAMLErrorPayload with a `var` for IE10 compatibility. Babel doesn't transform the const to a var when it is exported as a string.

Closes DCOS-17611