### PR TITLE
Only import used function from package

### DIFF
--- a/lib/raml-validator-loader.js
+++ b/lib/raml-validator-loader.js
@@ -55,8 +55,6 @@ module.exports =
 
 	var _raml1Parser = __webpack_require__(2);
 
-	var _raml1Parser2 = _interopRequireDefault(_raml1Parser);
-
 	var _Generator = __webpack_require__(3);
 
 	var _Generator2 = _interopRequireDefault(_Generator);
@@ -84,7 +82,7 @@ module.exports =
 	  // 1) Provide a custom content for the source file
 	  // 2) Track dependent files in order for webpack to invalidate caches
 	  //
-	  var raml = _raml1Parser2.default.loadApiSync(this.resourcePath, {
+	  var raml = (0, _raml1Parser.loadApiSync)(this.resourcePath, {
 	    fsResolver: {
 	      content: function content(path) {
 	        if (path === _this.resourcePath) {

--- a/src/raml-validator-loader.js
+++ b/src/raml-validator-loader.js
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import RAML from 'raml-1-parser';
+import { loadApiSync } from 'raml-1-parser';
 
 import Generator from './Generator';
 import GeneratorContext from './GeneratorContext';
@@ -20,7 +20,7 @@ module.exports = function (source) {
   // 1) Provide a custom content for the source file
   // 2) Track dependent files in order for webpack to invalidate caches
   //
-  const raml = RAML.loadApiSync(this.resourcePath, {
+  const raml = loadApiSync(this.resourcePath, {
     fsResolver: {
       content: (path) => {
         if (path === this.resourcePath) {


### PR DESCRIPTION
The previous statement lead to an error in recent node versions,
because there is no default export provided in raml-1-parser.